### PR TITLE
fix: Cannot install package from github

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: lint
         run: poetry run lint
       - name: format
-        run: poetry run format
+        run: poetry run black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ mypy = "^0.931"
 
 [tool.poetry.scripts]
 lint = "flake8.main.cli:main"
-format = "black:main('.')"
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
## Description
Installing the `gliff` package from github with `pip install git+https://github.com/gliff-ai/gliff-py.git#egg=gliff` fails with error "EntryPoint must be in 'name=module:attrs [extras]' format", "format=black:main('.')".

black takes as attribute a source file or directory and I can't find a way to pass attributes to poetry scripts, so I am removing the "format" script, untill I can find a solution.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
