### PR TITLE
feat: Support RBG images stored as a list of separate channels

### DIFF
--- a/gliff.py
+++ b/gliff.py
@@ -741,7 +741,7 @@ class Gliff:
 
         logger.success("metadata updated.")
 
-    def get_image_data(self, project_uid: str, item_uid: str) -> Union[List[List[Image.Image]], None]:
+    def get_image_data(self, project_uid: str, item_uid: str) -> Union[Image.Image, None]:
         """Get the image data from an image item.
 
         Parameters
@@ -773,8 +773,20 @@ class Gliff:
                 for i_channel in range(len(decoded_content[i_slice])):
                     image_data[i_slice].append(self.base64_to_pil_image(decoded_content[i_slice][i_channel]))
 
+            num_channels = len(image_data[0])
+            if num_channels == 1:
+                image_pil = image_data[0][0]
+
+            elif num_channels == 3:
+                red, green, blue = [img.getchannel(i) for i, img in enumerate(image_data[0])]
+                image_pil = Image.merge("RGB", (red, green, blue))
+
+            else:
+                logger.error(f"Images with {num_channels} channels are not supported.")
+                return None
+
             logger.success("image data fetched.")
-            return image_data
+            return image_pil
         except Exception as e:
             logger.error(f"Error while fetching an item's image data: {e}")
         return None


### PR DESCRIPTION
## Description
Support RBG images stored as a list of separate channels.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
